### PR TITLE
Fix a bug and inlcuding a new method called north_american_area_code_for

### DIFF
--- a/lib/itu_codes.rb
+++ b/lib/itu_codes.rb
@@ -102,6 +102,7 @@ module ItuCodes
     # parse a destination code (probably with area code) to find the number without the ITU code
     #   ex:  parse_number(18184443322) => 8184443322
     def parse_number(some_number)
+      some_number = clean(some_number)
       country_code = parse_code(some_number)
       some_number[country_code.length,some_number.length] unless country_code.nil?
     end

--- a/test/itu_codes_test.rb
+++ b/test/itu_codes_test.rb
@@ -43,6 +43,21 @@ lambda do
 end.call
 
 lambda do
+  #test parse full number with invalid characters
+  american  =    "1"
+  only_characters = american+"abdcedfgh"
+  characters_and_numbers = american+"abdefg301h33i11j871"
+  symbol_characters = american+'%$#.#@*-_,'
+  symbol_characters_and_numbers = american+'-*&.$301-331-1871'
+
+  assert ItuCodes.parse_number(only_characters), :== => ""
+  assert ItuCodes.parse_number(symbol_characters), :== => ""
+  assert ItuCodes.parse_number(characters_and_numbers), :== => "3013311871"
+  assert ItuCodes.parse_number(symbol_characters_and_numbers), :== => "3013311871"
+
+end.call
+
+lambda do
   # test compatriot phone numbers should be detected
   american  =    "1"
   newyorker = "1212"


### PR DESCRIPTION
I did 3 commits, I'll explain the changes made and the reason to do so.

Commit 1

I was having a lot of trouble to even run the test, in order to solve that for me and the futures contributors, I made the following changes:

1-Added require_relative as needed.
2-Especify ruby 1.9.3 in gemfile.

Commit 2

I notice that when you try to parse a number like this '1-_304-8879463', it returns '-_304-8879463' (without removing the non-numeric characters), even further, when you try to parse a number with special characters and things that shouldn't be there, it was keeping them, so I made the following changes:

1-Add clear in the input number in  parse_number before start procesing it.
2-Make more tests to parse_number, checking the case when the number contains invalid characters.

Commit 3

This is a feature that I really need, and maybe others will find useful too, be able to take the area code out of the cellphone number of a north american phone. Changes made:

1- Create a method called north_american_area_code_for(some_number).
2- Create the test for north_american_area_code_for.

Please if you have any questions be free to ask in the comments, I have more bug fixes to pull, but I prefer to wait until you review and aprove these.

Cheers,
David T.
