### PR TITLE
Added method north_american_area_code_for and add the proper test.

### DIFF
--- a/lib/itu_codes.rb
+++ b/lib/itu_codes.rb
@@ -99,6 +99,24 @@ module ItuCodes
       some_number[0,sub_index] unless sub_index.nil?
     end
 
+    # parse a north american full number and return the area code
+    # returns nil if the number is not north american
+    # return 1, if can't find an area code in Constants::NORTH_AMERICAN_AREA_CODES
+    #  ex:   north_american_area_code_for("1-264-9568543") => 1264
+    def north_american_area_code_for(some_number)
+      some_number = clean(some_number)
+
+      itu_code  = parse_code(some_number)
+
+      return nil if itu_code.nil? || !north_american?(itu_code)
+
+      code = itu_code
+
+      north_american_codes.each { |_, v| code = some_number[0,4] if v.include?(some_number[0,4]) }
+
+      return code
+    end
+
     # parse a destination code (probably with area code) to find the number without the ITU code
     #   ex:  parse_number(18184443322) => 8184443322
     def parse_number(some_number)

--- a/test/itu_codes_test.rb
+++ b/test/itu_codes_test.rb
@@ -58,6 +58,25 @@ lambda do
 end.call
 
 lambda do
+  #test north_american_area_code_for
+  usa_code_1    =  "1201"
+  usa_code_2    =  "1240-30476563"
+  canada_code_1 =  "1204"
+  canada_code_2 =  "1450-89909876"
+  anguilla_1    =  "1264"
+  anguilla_2    =  "1-264-9568543"
+
+  assert ItuCodes.north_american_area_code_for(usa_code_1),    :== => "1201"
+  assert ItuCodes.north_american_area_code_for(usa_code_2),    :== => "1240"
+  assert ItuCodes.north_american_area_code_for(canada_code_1), :== => "1204"
+  assert ItuCodes.north_american_area_code_for(canada_code_2), :== => "1450"
+  assert ItuCodes.north_american_area_code_for(anguilla_1),    :== => "1264"
+  assert ItuCodes.north_american_area_code_for(anguilla_2),    :== => "1264"
+
+
+end.call
+
+lambda do
   # test compatriot phone numbers should be detected
   american  =    "1"
   newyorker = "1212"


### PR DESCRIPTION
This is a feature that I really need, and maybe others will find useful too, be able to take the area code out of the cellphone number of a north american phone. Changes made:

1- Create a method called north_american_area_code_for(some_number).
2- Create the test for north_american_area_code_for.
